### PR TITLE
Add Helm chart README to .gitignore (#36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ k8sgpt_*.deb
 
 # Docs
 microk8s_setup_and_ai_interaction_command_line_instructions.md
+/helm-chart/README.md


### PR DESCRIPTION
Closes #36 