### PR TITLE
Fix missed gateway migration / add LocalAI env values / add test cert (#39)

### DIFF
--- a/helm-chart/localai-values.yaml
+++ b/helm-chart/localai-values.yaml
@@ -8,27 +8,14 @@ service:
 
 # Gateway API disabled (using ingress instead)
 gateway:
-  enabled: false
-
-# Ingress configuration
-ingress:
   enabled: true
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: selfsigned-issuer
-  hosts:
-    - host: example.local
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: example-cert-tls
-      hosts:
-        - example.local
 
 # LocalAI configuration
 localai:
   enabled: true
+  env:
+    CONTEXT_SIZE: "0"
+    THREADS: "4"
   persistence:
     models:
       enabled: true

--- a/helm-chart/test-certificate.yaml
+++ b/helm-chart/test-certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert
+  namespace: localai
+spec:
+  secretName: test-cert-tls
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  commonName: test.local
+  dnsNames:
+  - test.local
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+


### PR DESCRIPTION
# Migration from Ingress to Gateway API and TLS Configuration Updates

## Overview
This PR finalizes the migration from Kubernetes Ingress to the Gateway API for the LocalAI deployment, a process originally intended to be completed in https://github.com/mattfsourcecode/ai-kubernetes-gateway/pull/2. It also introduces improvements to TLS testing capabilities and updates environment variables for the LocalAI depoyment.

Although concerns have previously been addressed in individual PRs, a [**DEVELOPMENT PAUSE** has been declared in the README](https://github.com/mattfsourcecode/ai-kubernetes-gateway?tab=readme-ov-file#-%EF%B8%8F-experimental-status-and-development-pause), with this PR focusing on resolving several outstanding issues that were in-progress when the pause went into effect. With this merge, https://github.com/mattfsourcecode/ai-kubernetes-gateway/issues/48 now blocks all future pull requests.

## Key Changes

### Completion of Gateway API Migration
- Removes legacy Ingress configuration from `localai-values.yaml`
- Implements Gateway API support in `localai-values.yaml` for enhanced traffic management
- Updates configuration to align with Gateway API best practices

### LocalAI Environment Variables
- **`CONTEXT_SIZE=0`**: Disables token context limitations
- **`THREADS=4`**: Configures the number of CPU threads for model processing

### TLS Configuration
- Adds `test-certificate.yaml` for TLS configuration testing

## Testing
- Verified Gateway API functionality
- Tested TLS certificate generation
- Confirmed service connectivity
- Validated model persistence

---

Closes #39 